### PR TITLE
Added retry flags to curl

### DIFF
--- a/vagrant/openshift-0.6.x/Vagrantfile
+++ b/vagrant/openshift-0.6.x/Vagrantfile
@@ -15,7 +15,7 @@ fi
 
 mkdir /tmp/openshift
 echo "Downloading OpenShift binaries..."
-curl -sSL https://github.com/openshift/origin/releases/download/v0.6.2/openshift-origin-v0.6.2-6a30f4d-linux-amd64.tar.gz | tar xzv -C /tmp/openshift
+curl --retry 999 --retry-max-time 0  -sSL https://github.com/openshift/origin/releases/download/v0.6.2/openshift-origin-v0.6.2-6a30f4d-linux-amd64.tar.gz | tar xzv -C /tmp/openshift
 mv /tmp/openshift/* /usr/bin/
 
 mkdir /var/lib/openshift

--- a/vagrant/openshift-1.0.x/Vagrantfile
+++ b/vagrant/openshift-1.0.x/Vagrantfile
@@ -24,7 +24,7 @@ fi
 
 mkdir /tmp/openshift
 echo "Downloading OpenShift binaries..."
-curl -sSL https://github.com/openshift/origin/releases/download/v1.0.0/openshift-origin-v1.0.0-67617dd-linux-amd64.tar.gz | tar xzv -C /tmp/openshift
+curl --retry 999 --retry-max-time 0  -sSL https://github.com/openshift/origin/releases/download/v1.0.0/openshift-origin-v1.0.0-67617dd-linux-amd64.tar.gz | tar xzv -C /tmp/openshift
 mv /tmp/openshift/* /usr/bin/
 
 mkdir -p /var/lib/openshift/openshift.local.manifests

--- a/vagrant/openshift-latest/Vagrantfile
+++ b/vagrant/openshift-latest/Vagrantfile
@@ -24,7 +24,7 @@ fi
 
 mkdir /tmp/openshift
 echo "Downloading OpenShift binaries..."
-curl -sSL https://github.com/openshift/origin/releases/download/v1.0.0/openshift-origin-v1.0.0-67617dd-linux-amd64.tar.gz | tar xzv -C /tmp/openshift
+curl --retry 999 --retry-max-time 0  -sSL https://github.com/openshift/origin/releases/download/v1.0.0/openshift-origin-v1.0.0-67617dd-linux-amd64.tar.gz | tar xzv -C /tmp/openshift
 mv /tmp/openshift/* /usr/bin/
 
 mkdir -p /var/lib/openshift/openshift.local.manifests


### PR DESCRIPTION
to avoid this error:

``` bash
==> default: Downloading OpenShift binaries...
==> default: ./
==> default: ./oc
==> default: curl: (56) TCP connection reset by peer
==> default: 
==> default: gzip: stdin: unexpected end of file
==> default: tar: Unexpected EOF in archive
==> default: tar: Unexpected EOF in archive
```
