### PR TITLE
port needs to be an explicit string so it won't be parsed as int

### DIFF
--- a/vagrant/openshift/Vagrantfile
+++ b/vagrant/openshift/Vagrantfile
@@ -254,7 +254,7 @@ spec:
     - name: ELASTICSEARCH_HOST
       value: elasticsearch
     - name: ELASTICSEARCH_PORT
-      value: 9200
+      value: "9200"
   volumes:
   - name: varlog
     hostPath:


### PR DESCRIPTION
port needs to be an explicit string so it won't be parsed as int
