### PR TITLE
Removed reference to hostmanager-fabric8 in Vagrantfile for kubernetes

### DIFF
--- a/vagrant/kubernetes/Vagrantfile
+++ b/vagrant/kubernetes/Vagrantfile
@@ -137,10 +137,7 @@ SCRIPT
 
 $windows = (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
 
-if $windows && Vagrant.has_plugin?("vagrant-hostmanager")
-  raise 'Conflicting vagrant plugin detected - please uninstall & then try again: vagrant plugin uninstall vagrant-hostmanager'
-end
-$pluginToCheck = $windows ? "vagrant-hostmanager-fabric8" : "landrush"
+$pluginToCheck = $windows ? "vagrant-hostmanager" : "landrush"
 unless Vagrant.has_plugin?($pluginToCheck)
   raise 'Please type this command then try again: vagrant plugin install ' + $pluginToCheck
 end

--- a/vagrant/sandbox/kubernetes-no-docker/Vagrantfile
+++ b/vagrant/sandbox/kubernetes-no-docker/Vagrantfile
@@ -209,10 +209,7 @@ SCRIPT
 
 $windows = (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
 
-if $windows && Vagrant.has_plugin?("vagrant-hostmanager")
-  raise 'Conflicting vagrant plugin detected - please uninstall & then try again: vagrant plugin uninstall vagrant-hostmanager'
-end
-$pluginToCheck = $windows ? "vagrant-hostmanager-fabric8" : "landrush"
+$pluginToCheck = $windows ? "vagrant-hostmanager" : "landrush"
 unless Vagrant.has_plugin?($pluginToCheck)
   raise 'Please type this command then try again: vagrant plugin install ' + $pluginToCheck
 end


### PR DESCRIPTION
This fix is similar to [Removed reference to hostmanager-fabric8 and switched back to vanilla… by rhuss · Pull Request #43 · fabric8io/fabric8-installer](https://github.com/fabric8io/fabric8-installer/pull/43).
#43 is only for `open shift`, but my fixies are for `kubernetes` and `kubernetes-no-docker`.

And I checked that there isn't the reference to hostmanager-fabric8 in this repository.
