### PR TITLE
Openshift Vagrant box: align OPENSHIFT_VERSION

### DIFF
--- a/vagrant/openshift/Vagrantfile
+++ b/vagrant/openshift/Vagrantfile
@@ -63,7 +63,7 @@ mkdir /tmp/openshift
 echo "Downloading OpenShift binaries..."
 
 # NOTE make sure the OpenShift version matches the same one in the download URL!
-OPENSHIFT_VERSION="1.3.0-alpha.1"
+OPENSHIFT_VERSION="1.3.0-alpha.2"
 curl --retry 999 --retry-max-time 0 -sSL https://github.com/openshift/origin/releases/download/v1.3.0-alpha.2/openshift-origin-server-v1.3.0-alpha.2-983578e-linux-64bit.tar.gz | tar xzv -C /tmp/openshift
 mv /tmp/openshift/openshift-origin-*/* /usr/bin/
 


### PR DESCRIPTION
The Vagrantfile of openshift was erroneously pointing to the alpha1 instead of alpha2
